### PR TITLE
Fixes for unity compatiblity in KSP 1.8.1

### DIFF
--- a/scatterer/Core.cs
+++ b/scatterer/Core.cs
@@ -41,7 +41,7 @@ namespace scatterer
 		}
 
 		public Rect windowRect = new Rect (0, 0, 400, 50);
-		int windowId = UnityEngine.Random.Range(int.MinValue,int.MaxValue);
+		int windowId = 0;
 
 		GUIhandler GUItool= new GUIhandler();
 
@@ -824,6 +824,9 @@ namespace scatterer
 		{
 			if (visible)
 			{
+				if (windowId == 0)
+					windowId = UnityEngine.Random.Range(int.MinValue,int.MaxValue);
+
 				windowRect = GUILayout.Window (windowId, windowRect, GUItool.DrawScattererWindow,"Scatterer v"+versionNumber+": "
 				                               + guiModifierKey1String+"/"+guiModifierKey2String +"+" +guiKey1String
 				                               +"/"+guiKey2String+" toggle");

--- a/scatterer/GUI/GUIhandler.cs
+++ b/scatterer/GUI/GUIhandler.cs
@@ -15,10 +15,6 @@ namespace scatterer
 {
 	public class GUIhandler: MonoBehaviour
 	{
-
-		public Rect windowRect = new Rect (0, 0, 400, 50);
-		int windowId = UnityEngine.Random.Range(int.MinValue,int.MaxValue);
-
 		public int selectedPlanet = 0;
 		public int selectedConfigPoint = 0;
 		bool wireFrame = false;


### PR DESCRIPTION
Fixes loading exceptions:
UnityException: RandomRangeInt is not allowed to be called from a MonoBehaviour constructor (or instance field initializer), call it in Awake or Start instead. Called from MonoBehaviour 'Core' on game object 'Core'.