### PR TITLE
Small step towards VR sunflares

### DIFF
--- a/scatterer/Effects/SunFlare/SunFlare.cs
+++ b/scatterer/Effects/SunFlare/SunFlare.cs
@@ -133,7 +133,7 @@ namespace Scatterer
 
 		public void updateProperties()
 		{
-			sunViewPortPos = Scatterer.Instance.scaledSpaceCamera.WorldToViewportPoint (sourceScaledTransform.position);
+			sunViewPortPos = Scatterer.Instance.scaledSpaceCamera.WorldToViewportPoint (sourceScaledTransform.position, Camera.current.stereoActiveEye);
 			hitStatus=false;
 
 			if (sunViewPortPos.z > 0)
@@ -225,6 +225,11 @@ namespace Scatterer
 						hitStatus=false;
 				}
 
+				// For whatever reason, calling SetVector on the material doesn't work for the right eye in VR
+				// but calling Shader.SetGlobalVector does (note OnPreRender is called for each eye)
+				// However this will probably break situations where more than one star has an active lens flare
+				// so I don't want to enable that by default.
+				// Shader.SetGlobalVector(ShaderProperties.sunViewPortPos_PROPERTY, sunViewPortPos);
 				sunglareMaterial.SetVector (ShaderProperties.sunViewPortPos_PROPERTY, sunViewPortPos);
 
 				if (!(HighLogic.LoadedScene == GameScenes.TRACKSTATION))

--- a/scatterer/Effects/SunFlare/SunflareCameraHook.cs
+++ b/scatterer/Effects/SunFlare/SunflareCameraHook.cs
@@ -34,7 +34,7 @@ namespace Scatterer
 
 		public void OnPostRender()
 		{
-			if(flare)
+			if(flare && Camera.current.stereoActiveEye != Camera.MonoOrStereoscopicEye.Left)
 			{
 				flare.ClearExtinction ();
 				flare.sunglareMaterial.SetFloat(ShaderProperties.renderOnCurrentCamera_PROPERTY,0.0f);


### PR DESCRIPTION
-use the correct eye to calculate the sun's viewport position
-don't reset extinction until the right eye is done
-however something isn't working properly; the sun's viewport position doesn't seem to get updated in the shader properties for the right eye.  Using Shader.SetGlobalVector instead of Material.SetVector seems to work, but that would break multi-star systems.