### PR TITLE
Fixed all exceptions in debug player

### DIFF
--- a/scatterer/Effects/AntiAliasing/SubpixelMorphologicalAntialiasing.cs
+++ b/scatterer/Effects/AntiAliasing/SubpixelMorphologicalAntialiasing.cs
@@ -34,7 +34,7 @@ namespace scatterer
 		static Texture2D areaTex, searchTex;
 		bool initialized = false;
 
-		public SubpixelMorphologicalAntialiasing()
+		public void Awake()
 		{
 			targetCamera = GetComponent<Camera> ();
 			

--- a/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
+++ b/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
@@ -38,7 +38,7 @@ namespace scatterer
 		public bool checkOceanDepth = false;
 		public bool jitterTransparencies = false;
 
-		public TemporalAntiAliasing()
+		public void Awake()
 		{
 			targetCamera = GetComponent<Camera>();
 			originalDepthTextureMode = targetCamera.depthTextureMode;

--- a/scatterer/Effects/Proland/Atmosphere/SkyNode.cs
+++ b/scatterer/Effects/Proland/Atmosphere/SkyNode.cs
@@ -791,7 +791,7 @@ namespace scatterer
 				}
 			}
 
-			if (!ReferenceEquals(originalScaledMesh,null))
+			if (parentScaledTransform != null && !ReferenceEquals(originalScaledMesh,null))
 				parentScaledTransform.GetComponent<MeshFilter> ().sharedMesh = originalScaledMesh;
 
 			RestoreStockScaledTexture ();
@@ -965,8 +965,12 @@ namespace scatterer
 					materials.Last().SetShaderPassEnabled("ForwardAdd", true);
 					materials.Last().renderQueue = 2002;
 
-					PlanetSecondaryLightUpdater secondaryLightUpdater = parentScaledTransform.gameObject.AddComponent<PlanetSecondaryLightUpdater>();
-					secondaryLightUpdater.Init(planetScaledSpaceMaterial, materials.Last());
+					// Starting a coroutine on an inactive object causes an exception.
+					if (parentScaledTransform.gameObject.activeInHierarchy)
+					{
+						PlanetSecondaryLightUpdater secondaryLightUpdater = parentScaledTransform.gameObject.AddComponent<PlanetSecondaryLightUpdater>();
+						secondaryLightUpdater.Init(planetScaledSpaceMaterial, materials.Last());
+					}
 				}
 
 				materials.Add(scaledEclipseMaterial);

--- a/scatterer/Effects/Proland/Ocean/OceanFFTgpu.cs
+++ b/scatterer/Effects/Proland/Ocean/OceanFFTgpu.cs
@@ -62,7 +62,7 @@ namespace scatterer {
 
 		public int m_fourierGridSize = 64;										//This is the fourier transform size, must pow2 number. Recommend no higher or lower than 64, 128 or 256.
 		
-		private int m_varianceSize = SystemInfo.supportsComputeShaders ? 16 : 4;
+		private int m_varianceSize;
 		
 		float m_fsize;
 		float m_maxSlopeVariance;
@@ -121,6 +121,8 @@ namespace scatterer {
 		public override void Init(ProlandManager manager)
 		{
 			base.Init(manager);
+
+			m_varianceSize = SystemInfo.supportsComputeShaders ? 16 : 4; // SystemInfo.supportsComputeShaders must not be called from a field initialiser.
 
 			if (m_gravity == 0f)
 			{

--- a/scatterer/Effects/Proland/ProlandManager.cs
+++ b/scatterer/Effects/Proland/ProlandManager.cs
@@ -81,8 +81,11 @@ namespace scatterer
 
 			if (HighLogic.LoadedScene == GameScenes.MAINMENU)
 			{
-					parentScaledTransform = Utils.GetMainMenuObject(scattererBody.celestialBody).transform;
-					parentLocalTransform  = Utils.GetMainMenuObject(scattererBody.celestialBody).transform;
+				if (!Utils.GetMainMenuObject(scattererBody.celestialBody, out GameObject menuObject))
+					return;
+
+				parentScaledTransform = menuObject.transform;
+				parentLocalTransform  = menuObject.transform;
 			}
 			else
 			{
@@ -95,8 +98,7 @@ namespace scatterer
 
 			if (HighLogic.LoadedScene == GameScenes.MAINMENU)
 			{
-				GameObject _go = Utils.GetMainMenuObject(scattererBody.celestialBody);
-				if (_go)
+				if (Utils.GetMainMenuObject(scattererBody.celestialBody, out GameObject _go))
 				{
 					MeshRenderer _mr = _go.GetComponent<MeshRenderer> ();
 					if (_mr)

--- a/scatterer/Effects/ScattererCelestialBodiesManager.cs
+++ b/scatterer/Effects/ScattererCelestialBodiesManager.cs
@@ -131,6 +131,10 @@ namespace scatterer
 
 		void loadEffectsForBody (ScattererCelestialBody scattererCelestialBody)
 		{
+			// Totally skip bodies that aren't in the scene.
+			if (HighLogic.LoadedScene == GameScenes.MAINMENU && !Utils.GetMainMenuObject(scattererCelestialBody.celestialBody, out GameObject _))
+				return;
+
 			try
 			{
 				if (HighLogic.LoadedScene == GameScenes.TRACKSTATION || HighLogic.LoadedScene == GameScenes.MAINMENU)

--- a/scatterer/Effects/SunFlare/SunFlare.cs
+++ b/scatterer/Effects/SunFlare/SunFlare.cs
@@ -30,11 +30,11 @@ namespace scatterer
 		static Dictionary<string, Texture2D> texturesDictionary = new Dictionary<string, Texture2D> ();
 
 		//Size is loaded automatically from the files
-		Texture2D sunSpikes = new Texture2D (1, 1);
-		Texture2D sunFlare  = new Texture2D (1, 1);
-		Texture2D sunGhost1 = new Texture2D (1, 1);
-		Texture2D sunGhost2 = new Texture2D (1, 1);
-		Texture2D sunGhost3 = new Texture2D (1, 1);
+		Texture2D sunSpikes;
+		Texture2D sunFlare;
+		Texture2D sunGhost1;
+		Texture2D sunGhost2;
+		Texture2D sunGhost3;
 
 		public RenderTexture extinctionTexture;
 		int waitBeforeReloadCnt = 0;
@@ -67,6 +67,16 @@ namespace scatterer
 		//Syntax V2 settings
 		SunflareSettingsV2 settingsV2;
 
+		public void Awake()
+		{
+			// Creating textures in field initialisers can cause exceptions.
+
+			sunSpikes = new Texture2D(1, 1);
+			sunFlare = new Texture2D(1, 1);
+			sunGhost1 = new Texture2D(1, 1);
+			sunGhost2 = new Texture2D(1, 1);
+			sunGhost3 = new Texture2D(1, 1);
+		}
 
 		public void start()
 		{

--- a/scatterer/Utilities/Misc/Utils.cs
+++ b/scatterer/Utilities/Misc/Utils.cs
@@ -58,18 +58,12 @@ namespace scatterer
 			Debug.LogError("[Scatterer][Error] " + log);
 		}
 
-		public static GameObject GetMainMenuObject(CelestialBody celestialBody)
+		public static bool GetMainMenuObject(CelestialBody celestialBody, out GameObject gameObject)
 		{
+			// Search all Rotatos for the one with the correct name.
 			string name = celestialBody.isHomeWorld ? "Kerbin" : celestialBody.name;
-
-			GameObject mainMenuObject = GameObject.FindObjectsOfType<GameObject>().FirstOrDefault(b => ( (b.name == name) && b.transform.parent.name.Contains("Scene")));
-			
-			if (ReferenceEquals(mainMenuObject,null))
-			{
-				throw new Exception("No correct main menu object found for "+celestialBody.name);
-			}
-			
-			return mainMenuObject;
+			gameObject = GameObject.FindObjectsOfType<Rotato>().Select(r => r.gameObject).FirstOrDefault(b => b.name == name);
+			return gameObject != null;
 		}
 		
 		public static Transform GetScaledTransform (string body)


### PR DESCRIPTION
Similar to https://github.com/LGhassen/Scatterer/pull/175, but deliberately targeted at master, as I believe master alone represents the source for the free version of Scatterer.

Consists of moving API usages out of field initialisers/constructors which were causing errors when running the game via the debug player, and some miscellaneous exceptions around atmosphere creation in the main menu.