### PR TITLE
Fix #225, Fix #236: use temporary RTs with the active camera dimensions to fix VR issues

### DIFF
--- a/scatterer/Effects/AntiAliasing/SubpixelMorphologicalAntialiasing.cs
+++ b/scatterer/Effects/AntiAliasing/SubpixelMorphologicalAntialiasing.cs
@@ -84,8 +84,9 @@ namespace Scatterer
 			quality = (Quality)((Int32) Mathf.Clamp( (float) Scatterer.Instance.mainSettings.smaaQuality,1f,2f));	//limit to 1 and 2, 1 and 2 are image-based. 0 is depth-based and would make performance worse by having to run for each camera's depth
 																													//only use depth mode when we force it for the IVA camera
 
-			SMAACommandBuffer = new CommandBuffer ();
-		}
+            SMAACommandBuffer = new CommandBuffer ();
+            SMAACommandBuffer.name = $"Scatterer SMAA CommandBuffer for {targetCamera.name}";
+        }
 
         static readonly int MainTextureProperty = Shader.PropertyToID("_MainTexture");
         static readonly int BlendTexproperty = Shader.PropertyToID("_BlendTex");

--- a/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
+++ b/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
@@ -281,7 +281,7 @@ namespace Scatterer
 				}
 				else
                 {
-					ConfigureJitteredProjectionMatrix();
+					ConfigureJitteredProjectionMatrix(targetCamera);
 
 					//TODO: move to shader properties
 					if (checkOceanDepth)

--- a/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
+++ b/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
@@ -65,33 +65,34 @@ namespace Scatterer
 			temporalAAMaterial.SetFloat("_Sharpness", sharpness);
 			temporalAAMaterial.SetVector("_FinalBlendParameters", new Vector4(stationaryBlending, motionBlending, kMotionAmplification, 0f));
 
-			temporalAACommandBuffer = new CommandBuffer ();
-		}
+			temporalAACommandBuffer = new CommandBuffer();
+			temporalAACommandBuffer.name = $"Scatterer TAA CommandBuffer for {targetCamera.name}";
+	}
 
 		internal DepthTextureMode GetCameraFlags()
 		{
 			return DepthTextureMode.Depth | DepthTextureMode.MotionVectors;
-		}
-		
-		internal void ResetHistory()
-		{
-			m_ResetHistory = true;
-		}
-		
-		Vector2 GenerateRandomOffset()
-		{
-			// The variance between 0 and the actual halton sequence values reveals noticeable instability
-			// in Unity's shadow maps, so we avoid index 0.
-			var offset = new Vector2(
-				HaltonSeq.Get((sampleIndex & 1023) + 1, 2) - 0.5f,
-				HaltonSeq.Get((sampleIndex & 1023) + 1, 3) - 0.5f
-				);
-			
-			if (++sampleIndex >= k_SampleCount)
-				sampleIndex = 0;
-			
-			return offset;
-		}
+        }
+        
+        internal void ResetHistory()
+        {
+            m_ResetHistory = true;
+        }
+        
+        Vector2 GenerateRandomOffset()
+        {
+            // The variance between 0 and the actual halton sequence values reveals noticeable instability
+            // in Unity's shadow maps, so we avoid index 0.
+            var offset = new Vector2(
+                HaltonSeq.Get((sampleIndex & 1023) + 1, 2) - 0.5f,
+                HaltonSeq.Get((sampleIndex & 1023) + 1, 3) - 0.5f
+                );
+            
+            if (++sampleIndex >= k_SampleCount)
+                sampleIndex = 0;
+            
+            return offset;
+        }
 
 		/// Gets a jittered perspective projection matrix for a given camera.
 		public static Matrix4x4 GetJitteredPerspectiveProjectionMatrix(Camera camera, Vector2 offset)

--- a/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
+++ b/scatterer/Effects/AntiAliasing/TemporalAntiAliasing.cs
@@ -25,7 +25,7 @@ namespace Scatterer
 		const int k_SampleCount = 8;
 		
 		// Ping-pong between two history textures as we can't read & write the same target in the same pass
-		const int eyesCount = 1; const int historyTexturesCount = 2;
+		const int eyesCount = 2; const int historyTexturesCount = 2;
 		RenderTexture[][] historyTextures = new RenderTexture[eyesCount][];
 
 		int[] m_HistoryPingPong = new int [eyesCount];
@@ -137,10 +137,8 @@ namespace Scatterer
 			temporalAAMaterial.SetVector(jitterProperty, jitter);
 		}
 		
-		RenderTexture CheckHistory(int id, CommandBuffer cmd)
-		{
-			int activeEye = 0;
-			
+		RenderTexture CheckHistory(int id, CommandBuffer cmd, int activeEye)
+		{	
 			if (historyTextures[activeEye] == null)
 				historyTextures[activeEye] = new RenderTexture[historyTexturesCount];
 
@@ -193,11 +191,11 @@ namespace Scatterer
 			{ 
 				temporalAACommandBuffer.Clear();
 
-				int activeEye = 0;
+				int activeEye = targetCamera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Right ? 1 : 0;
 
 				int pingPongIndex = m_HistoryPingPong[activeEye];
-				RenderTexture historyRead = CheckHistory(++pingPongIndex % 2, temporalAACommandBuffer);
-				RenderTexture historyWrite = CheckHistory(++pingPongIndex % 2, temporalAACommandBuffer);
+				RenderTexture historyRead = CheckHistory(++pingPongIndex % 2, temporalAACommandBuffer, activeEye);
+				RenderTexture historyWrite = CheckHistory(++pingPongIndex % 2, temporalAACommandBuffer, activeEye);
 				m_HistoryPingPong[activeEye] = ++pingPongIndex % 2;
 
 				if (firstFrame)
@@ -280,6 +278,7 @@ namespace Scatterer
 
 			sampleIndex = 0;
 			m_HistoryPingPong[0] = 0;
+			m_HistoryPingPong[1] = 1;
 
 			ResetHistory();
 

--- a/scatterer/Effects/Proland/Atmosphere/Godrays/LegacyGodraysRenderer.cs
+++ b/scatterer/Effects/Proland/Atmosphere/Godrays/LegacyGodraysRenderer.cs
@@ -114,9 +114,10 @@ namespace Scatterer
 			//since they are exposed in shaders we use a compute shader to do it
 			inverseShadowMatricesBuffer = new ComputeBuffer (4, 16 * sizeof(float));
 
-			shadowVolumeCB = new CommandBuffer();
-			shadowVolumeCB.SetComputeBufferParam (inverseShadowMatricesComputeShader, 0, "resultBuffer", inverseShadowMatricesBuffer);
-			shadowVolumeCB.DispatchCompute(inverseShadowMatricesComputeShader, 0, 4, 1, 1);
+            shadowVolumeCB = new CommandBuffer();
+            shadowVolumeCB.name = "Scatterer legacy godrays CommandBuffer";
+            shadowVolumeCB.SetComputeBufferParam (inverseShadowMatricesComputeShader, 0, "resultBuffer", inverseShadowMatricesBuffer);
+            shadowVolumeCB.DispatchCompute(inverseShadowMatricesComputeShader, 0, 4, 1, 1);
 
 			shadowVolumeCB.SetRenderTarget(volumeDepthTexture);
 			//shadowVolumeCB.ClearRenderTarget(false, true, Color.black, 1f); //do this after rendering

--- a/scatterer/Effects/Proland/Ocean/Caustics/CausticsLightRaysRenderer.cs
+++ b/scatterer/Effects/Proland/Ocean/Caustics/CausticsLightRaysRenderer.cs
@@ -175,14 +175,15 @@ namespace Scatterer
 			compositeLightRaysMaterial.SetColor(ShaderProperties._sunColor_PROPERTY, oceanNodeIn.prolandManager.getIntensityModulatedSunColor());
 			compositeLightRaysMaterial.SetVector ("_Underwater_Color", oceanNodeIn.m_UnderwaterColor);
 
-			commandBuffer = new CommandBuffer();
-			
-			//downscale depth to 1/16
-			commandBuffer.Blit(null, downscaledDepthRT, downscaleDepthMaterial, 0);
-			commandBuffer.SetGlobalTexture("ScattererDownscaledDepth", downscaledDepthRT);
-			
-			//render
-			commandBuffer.Blit(null, targetRT, CausticsLightRaysMaterial);
+            commandBuffer = new CommandBuffer();
+            commandBuffer.name = "Scatterer caustics renderer CommandBuffer";
+
+            //downscale depth to 1/16
+            commandBuffer.Blit(null, downscaledDepthRT, downscaleDepthMaterial, 0);
+            commandBuffer.SetGlobalTexture("ScattererDownscaledDepth", downscaledDepthRT);
+            
+            //render
+            commandBuffer.Blit(null, targetRT, CausticsLightRaysMaterial);
 
 			//bilateral blur, 2 taps seems enough
 			commandBuffer.SetGlobalVector ("BlurDir", new Vector2(0,1));

--- a/scatterer/Effects/Proland/Ocean/Caustics/CausticsShadowMaskModulate.cs
+++ b/scatterer/Effects/Proland/Ocean/Caustics/CausticsShadowMaskModulate.cs
@@ -60,9 +60,9 @@ namespace Scatterer
 
 				sunLight = inputSunlight;
 
-				m_Buffer = new CommandBuffer ();
-				m_Buffer.name = "CausticsShadowMaskmodulate";			
-				m_Buffer.Blit (null, BuiltinRenderTextureType.CurrentActive, CausticsShadowMaskModulateMaterial);
+                m_Buffer = new CommandBuffer ();
+                m_Buffer.name = "Scatterer caustics shadowMask modulate CommandBuffer";
+                m_Buffer.Blit (null, BuiltinRenderTextureType.CurrentActive, CausticsShadowMaskModulateMaterial);
 
 				AddCommandBuffer ();
 				isEnabled = true;

--- a/scatterer/Utilities/Camera/DepthToDistanceCommandBuffer.cs
+++ b/scatterer/Utilities/Camera/DepthToDistanceCommandBuffer.cs
@@ -18,7 +18,7 @@ namespace Scatterer
             // after depth texture is rendered on far and near cameras, copy it and merge it as a single distance buffer
             camera = gameObject.GetComponent<Camera>();
             buffer = new CommandBuffer();
-            buffer.name = "EVEDepthToDistanceCommandBuffer";
+            buffer.name = "Scatterer DepthToDistanceCommandBuffer";
 
             if (!renderTexture)
             {

--- a/scatterer/Utilities/Occlusion/ShadowMapCopier.cs
+++ b/scatterer/Utilities/Occlusion/ShadowMapCopier.cs
@@ -62,12 +62,13 @@ namespace Scatterer
 			CreateTextureCopyCB ();
 		}
 
-		//Adds one one commandbuffer which does an optimized pixel-by-pixel texture copy
-		private void CreateTextureCopyCB()
-		{
-			textureCopyBuffer = new CommandBuffer();
-			textureCopyBuffer.CopyTexture (BuiltinRenderTextureType.CurrentActive, ShadowMapCopy.RenderTexture);
-		}
+        //Adds one one commandbuffer which does an optimized pixel-by-pixel texture copy
+        private void CreateTextureCopyCB()
+        {
+            textureCopyBuffer = new CommandBuffer();
+            textureCopyBuffer.name = "Scatterer shadowMap copy CommandBuffer";
+            textureCopyBuffer.CopyTexture (BuiltinRenderTextureType.CurrentActive, ShadowMapCopy.RenderTexture);
+        }
 
 		//These are adapted for copying one cascade and then rendering other stuff on top, like clouds, however since I'm going to render them separately, better do a fast copytexture
 		private void CreateCopyCascadeCBs()
@@ -78,10 +79,11 @@ namespace Scatterer
 			copyCascadeCB3 = CreateCopyCascadeCB (ShadowMapCopy.RenderTexture, 0.5f, 0.5f, 0.5f, 0.5f);
 		}
 
-		private CommandBuffer CreateCopyCascadeCB(RenderTexture targetRt, float startX, float startY, float width, float height)
-		{
-			CommandBuffer cascadeCopyCB = new CommandBuffer();
-			Rect cascadeRect = new Rect ((int)(startX * targetRt.width), (int)(startY * targetRt.height), (int)(width * targetRt.width), (int)(height * targetRt.height));
+        private CommandBuffer CreateCopyCascadeCB(RenderTexture targetRt, float startX, float startY, float width, float height)
+        {
+            CommandBuffer cascadeCopyCB = new CommandBuffer();
+            cascadeCopyCB.name = "Scatterer shadowMap cascade copy CommandBuffer";
+            Rect cascadeRect = new Rect ((int)(startX * targetRt.width), (int)(startY * targetRt.height), (int)(width * targetRt.width), (int)(height * targetRt.height));
 
 			cascadeCopyCB.EnableScissorRect(cascadeRect);
 			cascadeCopyCB.SetShadowSamplingMode(BuiltinRenderTextureType.CurrentActive, ShadowSamplingMode.RawDepth);

--- a/scatterer/Utilities/Occlusion/ShadowMapRetrieveCommandBuffer.cs
+++ b/scatterer/Utilities/Occlusion/ShadowMapRetrieveCommandBuffer.cs
@@ -12,10 +12,10 @@ namespace Scatterer
 		private CommandBuffer m_Buffer;
 		private Light m_Light;
 
-		public void Start ()
-		{
-			m_Buffer = new CommandBuffer();
-			m_Buffer.name = "ScattererShadowMapRetrieve";
+        public void Start ()
+        {
+            m_Buffer = new CommandBuffer();
+            m_Buffer.name = "Scatterer ShadowMapRetrieve CommandBuffer";
 
 			//instead of making a copy like shadowMapCopyCommandbuffer, here we just set the shadowmap as a global texture, for access in shader
 			m_Buffer.SetGlobalTexture (ShaderProperties._ShadowMapTextureScatterer_PROPERTY, new RenderTargetIdentifier(BuiltinRenderTextureType.CurrentActive));

--- a/scatterer/Utilities/Occlusion/ShadowMapRetrieveCommandBuffer.cs
+++ b/scatterer/Utilities/Occlusion/ShadowMapRetrieveCommandBuffer.cs
@@ -12,7 +12,7 @@ namespace Scatterer
 		private CommandBuffer m_Buffer;
 		private Light m_Light;
 
-		public ShadowMapRetrieveCommandBuffer ()
+		public void Start ()
 		{
 			m_Buffer = new CommandBuffer();
 			m_Buffer.name = "ScattererShadowMapRetrieve";

--- a/scatterer/Utilities/Occlusion/ShadowMaskCopyCommandBuffer.cs
+++ b/scatterer/Utilities/Occlusion/ShadowMaskCopyCommandBuffer.cs
@@ -12,17 +12,17 @@ namespace Scatterer
 		private CommandBuffer m_Buffer;
 		private Light m_Light;
 
-		public ShadowMaskCopyCommandBuffer ()
-		{
-			// after light's screenspace shadow mask is computed, copy it
-			m_Buffer = new CommandBuffer();
-			m_Buffer.name = "ScattererScreenspaceShadowMaskCopy";
-			
-//			m_Buffer.Blit (BuiltinRenderTextureType.CurrentActive, Core.Instance.bufferRenderingManager.occlusionTexture);
-			
-			m_Light = GetComponent<Light>();
-			m_Light.AddCommandBuffer (LightEvent.AfterScreenspaceMask, m_Buffer);
-		}
+        public ShadowMaskCopyCommandBuffer ()
+        {
+            // after light's screenspace shadow mask is computed, copy it
+            m_Buffer = new CommandBuffer();
+            m_Buffer.name = "Scatterer ScreenspaceShadowMaskCopy CommandBuffer";
+            
+//            m_Buffer.Blit (BuiltinRenderTextureType.CurrentActive, Core.Instance.bufferRenderingManager.occlusionTexture);
+            
+            m_Light = GetComponent<Light>();
+            m_Light.AddCommandBuffer (LightEvent.AfterScreenspaceMask, m_Buffer);
+        }
 
 		public void OnDestroy ()
 		{

--- a/scatterer/Utilities/Occlusion/ShadowMaskModulateCommandBuffer.cs
+++ b/scatterer/Utilities/Occlusion/ShadowMaskModulateCommandBuffer.cs
@@ -13,11 +13,11 @@ namespace Scatterer
 		private Light m_Light;
 		private Material m_ShadowMaskModulateMaterial;
 
-		public ShadowMaskModulateCommandBuffer ()
-		{
-			// after light's screenspace shadow mask is computed, copy it
-			m_Buffer = new CommandBuffer();
-			m_Buffer.name = "ScattererScreenspaceShadowMaskmodulate";
+        public ShadowMaskModulateCommandBuffer ()
+        {
+            // after light's screenspace shadow mask is computed, copy it
+            m_Buffer = new CommandBuffer();
+            m_Buffer.name = "Scatterer ScreenspaceShadowMaskmodulate CommandBuffer";
 
 			m_ShadowMaskModulateMaterial = new Material (ShaderReplacer.Instance.LoadedShaders[("Scatterer/ModulateShadowMaskWithOcclusion")]);
 //			m_ShadowMaskModulateMaterial.SetTexture ("OcclusionTexture", Core.Instance.bufferRenderingManager.occlusionTexture);

--- a/scatterer/Utilities/Occlusion/ShadowRemoveFadeCommandBuffer.cs
+++ b/scatterer/Utilities/Occlusion/ShadowRemoveFadeCommandBuffer.cs
@@ -9,14 +9,14 @@ namespace Scatterer
 		private CommandBuffer m_Buffer;
 		private Camera m_Camera;
 
-		private void Awake ()
-		{
-			m_Buffer = new CommandBuffer();
-			m_Buffer.name = "ScattererShadowRemoveFade";
-					
-			//works for the fade but doesn't fix breaks in squares/axis-aligned lines near farclipPlane of nearCamera, limitation of what? idk
-			//could still be ok for SSAO, maybe passable for eclipses but not sure
-			m_Buffer.SetGlobalVector (ShaderProperties.unity_ShadowFadeCenterAndType_PROPERTY,new Vector4(float.PositiveInfinity,float.PositiveInfinity,float.PositiveInfinity,-1f));
+        private void Awake ()
+        {
+            m_Buffer = new CommandBuffer();
+            m_Buffer.name = "Scatterer ShadowRemoveFade CommandBuffer";
+                    
+            //works for the fade but doesn't fix breaks in squares/axis-aligned lines near farclipPlane of nearCamera, limitation of what? idk
+            //could still be ok for SSAO, maybe passable for eclipses but not sure
+            m_Buffer.SetGlobalVector (ShaderProperties.unity_ShadowFadeCenterAndType_PROPERTY,new Vector4(float.PositiveInfinity,float.PositiveInfinity,float.PositiveInfinity,-1f));
 
 			m_Camera = GetComponent<Camera>();
 			m_Camera.AddCommandBuffer (CameraEvent.BeforeForwardOpaque, m_Buffer);


### PR DESCRIPTION
fixes rendering in VR because it automatically gets the right size no matter what the camera dimensions are

also doesn't require special screenshot handling