### PR TITLE
Fix two bugs introduced by performance patches

### DIFF
--- a/scatterer/Effects/Proland/Ocean/OceanFFTgpu.cs
+++ b/scatterer/Effects/Proland/Ocean/OceanFFTgpu.cs
@@ -531,6 +531,7 @@ namespace Scatterer {
                         rnd3 = UnityEngine.Random.value
                     }
                 )
+                .ToList()
                 .AsParallel()
                 .Select(entry =>
                 {

--- a/scatterer/Effects/Proland/Ocean/Utils/WriteFloat.cs
+++ b/scatterer/Effects/Proland/Ocean/Utils/WriteFloat.cs
@@ -288,20 +288,18 @@ namespace Scatterer
             const float kEncodeBit = 1.0f / 255.0f;
             RGBAF kEncodeMul = new RGBAF { r = 1.0f, g = 255.0f, b = 65025.0f, a = 160581375.0f };
 
-            kEncodeMul.r *= val;
-            kEncodeMul.g *= val;
-            kEncodeMul.b *= val;
-            kEncodeMul.a *= val;
+            for (int i = 0; i < 4; ++i)
+            {
+                kEncodeMul[i] *= val;
+                kEncodeMul[i] = (float)(kEncodeMul[i] - System.Math.Truncate(kEncodeMul[i]));
+            }
 
-            kEncodeMul.r -= (float)Math.Truncate(kEncodeMul.r);
-            kEncodeMul.g -= (float)Math.Truncate(kEncodeMul.g);
-            kEncodeMul.b -= (float)Math.Truncate(kEncodeMul.b);
-            kEncodeMul.a -= (float)Math.Truncate(kEncodeMul.a);
-
-            kEncodeMul.r -= kEncodeMul.r * kEncodeBit;
-            kEncodeMul.g -= kEncodeMul.g * kEncodeBit;
-            kEncodeMul.b -= kEncodeMul.b * kEncodeBit;
-            kEncodeMul.a -= kEncodeMul.a * kEncodeBit;
+            // enc -= enc.yzww * kEncodeBit;
+            var yzww = new RGBAF { r = kEncodeMul[1], g = kEncodeMul[2], b = kEncodeMul[3], a = kEncodeMul[3] };
+            for (int i = 0; i < 4; ++i)
+            {
+                kEncodeMul[i] -= yzww[i] * kEncodeBit;
+            }
 
             return kEncodeMul;
         }


### PR DESCRIPTION
This fixes two bugs I introduced with my performance patches:
- `Random.data` is only supposed to be called on the main thread but `AsParallel()` will sometimes run the enumerator on a different thread.
- The new version of `EncodeFloatRGBA` is completely broken. I'm genuinely not sure how I didn't notice this when testing since it is incredibly obvious.

Anyway, this PR fixes both of those. It collects the random values into a list before calling `AsParallel` and it reverts the body of `EncodeFloatRGBA` to what it was before while still avoiding the allocations by using the `RGBAF` struct.

Here's everything working as expected with this PR applied:
<img width="2343" height="1110" alt="image" src="https://github.com/user-attachments/assets/af16fb3f-620a-48dd-a259-fbcaea4ec105" />
