### PR TITLE
Add some null checks to UpdateGraphicsUniforms()

### DIFF
--- a/scatterer/Effects/Proland/Atmosphere/SkyNode.cs
+++ b/scatterer/Effects/Proland/Atmosphere/SkyNode.cs
@@ -252,7 +252,7 @@ namespace Scatterer
 
 		public void UpdateGraphicsUniforms()
 		{
-			if (!inScaledSpace && !MapView.MapIsEnabled && postprocessingEnabled && localScatteringContainer!=null)
+			if (!inScaledSpace && !MapView.MapIsEnabled && postprocessingEnabled && localScatteringContainer != null)
 			{
 				UpdatePostProcessMaterialUniforms (localScatteringContainer.material);
 			}
@@ -269,7 +269,7 @@ namespace Scatterer
 				UpdateSunflareExtinctions ();
 			}
 
-			if (scaledScatteringContainer != null)
+			if (scaledScatteringContainer != null && scaledScatteringContainer.MeshRenderer != null)
 				scaledScatteringContainer.MeshRenderer.enabled = stockScaledPlanetMeshRenderer.enabled;
 
 			if (localScatteringContainer != null)
@@ -290,7 +290,9 @@ namespace Scatterer
 				
 				scaledEclipseMaterial.SetMatrix (ShaderProperties.lightOccluders1_PROPERTY, castersMatrix1);
 				scaledEclipseMaterial.SetMatrix (ShaderProperties.lightOccluders2_PROPERTY, castersMatrix2);
-				scaledEclipseMaterial.SetVector (ShaderProperties.sunPosAndRadius_PROPERTY, new Vector4 (sunPosRelPlanet.x, sunPosRelPlanet.y,
+
+				if (prolandManager.sunCelestialBody != null)
+					scaledEclipseMaterial.SetVector (ShaderProperties.sunPosAndRadius_PROPERTY, new Vector4 (sunPosRelPlanet.x, sunPosRelPlanet.y,
 				                                                                                         sunPosRelPlanet.z, (float)prolandManager.sunCelestialBody.Radius));
 			}
 		}


### PR DESCRIPTION
Recently saw a user in the RP-1 server [complaining](https://discord.com/channels/319857228905447436/331813459417235457/1431779638551773365) about NRE spam when switching to a vessel in the map view or tracking station. Obviously, this doesn't fix the original issue, but this PR does fix that NRE spam.

Relevant NRE:
```
[EXC 20:47:23.111] NullReferenceException
	Scatterer.SkyNode.UpdateGraphicsUniforms () (at <54f2924209e243e1ae5e4af0d4a9ce81>:0)
	Scatterer.SkyNode.OnPreRender () (at <54f2924209e243e1ae5e4af0d4a9ce81>:0)
	UnityEngine.DebugLogHandler:LogException(Exception, Object)
	ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
	UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
```

This attached log is an abridged version of the log that the user sent, which contains the logs after the scene switch to the track station (the original log was too big to attach here)
[abridged.log](https://github.com/user-attachments/files/23145432/abridged.log)

Edit: The user reported that reinstalling scatterer fixed whatever issue they had.
