### PR TITLE
Zero the per-frame/per-camera GC in OceanCameraUpdateHook.updateCameraSpecificUniforms

### DIFF
--- a/scatterer/Effects/Proland/Ocean/OceanCameraUpdateHook.cs
+++ b/scatterer/Effects/Proland/Ocean/OceanCameraUpdateHook.cs
@@ -9,6 +9,29 @@ namespace Scatterer
 
 		Matrix4x4 cameraToScreen,screenToCamera;
 		Matrix4x4d m_oldlocalToOcean = Matrix4x4d.Identity ();
+		bool m_oldlocalToOceanValid = false; // replaces the per-frame value-compare against a freshly allocated Matrix4x4d.Identity()
+
+		// Cached math objects. Matrix4x4d/Vector3d2 are classes, and this hook previously allocated
+		// ~30 of them per camera per frame (matrices, inverses, operator temporaries) - measured as
+		// ~4 KB/frame of pure GC pressure on a coastal scene. All formulas below are unchanged; only
+		// the allocation strategy changed to reuse these instances via the non-allocating Set/Multiply/
+		// InverseInto/MultiplyPoint/CrossInto variants.
+		readonly Matrix4x4d cameraToWorldD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d worldToLocalD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d camToLocalD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d localToCamD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d localToOceanD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d cameraToOceanD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d worldToOceanD = Matrix4x4d.Identity ();
+		readonly Matrix4x4d inverseScratchD = Matrix4x4d.Identity ();
+		readonly Vector3d2 zeroD = new Vector3d2 (0, 0, 0); // stands in for Vector3d2.Zero(); never mutated
+		readonly Vector3d2 scratchA = new Vector3d2 ();
+		readonly Vector3d2 scratchB = new Vector3d2 ();
+		readonly Vector3d2 deltaD = new Vector3d2 ();
+		readonly Vector3d2 sphereDirD = new Vector3d2 ();
+		readonly Vector3d2 sunDirD = new Vector3d2 ();
+		readonly Vector3d2 oceanSunDirD = new Vector3d2 ();
+		readonly Vector3d2 camPosLocalD = new Vector3d2 ();
 
 		// Whenever any camera will render us, call the method which updates the material with the right params
 		public void OnWillRenderObject()
@@ -58,11 +81,12 @@ namespace Scatterer
 			//move these to dedicated projected grid class?
 			
 			Matrix4x4 ctol1 = inCamera.cameraToWorldMatrix;
-			
-			Matrix4x4d cameraToWorld = new Matrix4x4d (ctol1.m00, ctol1.m01, ctol1.m02, ctol1.m03,
-			                                           ctol1.m10, ctol1.m11, ctol1.m12, ctol1.m13,
-			                                           ctol1.m20, ctol1.m21, ctol1.m22, ctol1.m23,
-			                                           ctol1.m30, ctol1.m31, ctol1.m32, ctol1.m33);
+
+			Matrix4x4d cameraToWorld = cameraToWorldD;
+			cameraToWorld.Set (ctol1.m00, ctol1.m01, ctol1.m02, ctol1.m03,
+			                   ctol1.m10, ctol1.m11, ctol1.m12, ctol1.m13,
+			                   ctol1.m20, ctol1.m21, ctol1.m22, ctol1.m23,
+			                   ctol1.m30, ctol1.m31, ctol1.m32, ctol1.m33);
 
 			Vector3d translation;
 
@@ -75,54 +99,67 @@ namespace Scatterer
 				translation = oceanNode.prolandManager.parentCelestialBody.position;		//more precise, especially with RSS, but breaks a bit in KSC
 			}
 
-			Matrix4x4d worldToLocal = new Matrix4x4d(1, 0, 0, -translation.x,
-			                                         0, 1, 0, -translation.y,
-			                                         0, 0, 1, -translation.z,
-			                                         0, 0, 0, 1);
-			
-			Matrix4x4d camToLocal = worldToLocal * cameraToWorld;
-			Matrix4x4d localToCam = camToLocal.Inverse ();
-			
+			Matrix4x4d worldToLocal = worldToLocalD;
+			worldToLocal.Set (1, 0, 0, -translation.x,
+			                  0, 1, 0, -translation.y,
+			                  0, 0, 1, -translation.z,
+			                  0, 0, 0, 1);
+
+			Matrix4x4d camToLocal = camToLocalD;
+			Matrix4x4d.Multiply (worldToLocal, cameraToWorld, camToLocal);
+			Matrix4x4d localToCam = localToCamD;
+			camToLocal.InverseInto (localToCam);
+
 			// camera in local space relative to planet's origin
-			Vector3d2 cl = new Vector3d2 ();
-			cl = camToLocal * Vector3d2.Zero ();
-			
+			Vector3d2 cl = camPosLocalD;
+			camToLocal.MultiplyPoint (zeroD, cl);
+
 			double radius = oceanNode.prolandManager.GetRadius ();
-			
-			oceanNode.uz = cl.Normalized (); // unit z vector of ocean frame, in local space
-			
-			if (m_oldlocalToOcean != Matrix4x4d.Identity ())
+
+			oceanNode.uz.CopyFrom (cl); // unit z vector of ocean frame, in local space
+			oceanNode.uz.Normalize ();
+
+			if (m_oldlocalToOceanValid)
 			{
-				oceanNode.ux = (new Vector3d2 (m_oldlocalToOcean.m [1, 0], m_oldlocalToOcean.m [1, 1], m_oldlocalToOcean.m [1, 2])).Cross (oceanNode.uz).Normalized ();
+				scratchA.Set (m_oldlocalToOcean.m [1, 0], m_oldlocalToOcean.m [1, 1], m_oldlocalToOcean.m [1, 2]);
+				scratchA.CrossInto (oceanNode.uz, oceanNode.ux);
+				oceanNode.ux.Normalize ();
 			}
-			else 
+			else
 			{
-				oceanNode.ux = Vector3d2.UnitZ ().Cross (oceanNode.uz).Normalized ();
+				scratchA.Set (0, 0, 1); // Vector3d2.UnitZ()
+				scratchA.CrossInto (oceanNode.uz, oceanNode.ux);
+				oceanNode.ux.Normalize ();
 			}
-			
-			oceanNode.uy = oceanNode.uz.Cross (oceanNode.ux); // unit y vector
+
+			oceanNode.uz.CrossInto (oceanNode.ux, oceanNode.uy); // unit y vector
 
 			//Wind moves in -Ux direction, which by default points north for some reason, can rotate it to any desired direction this way
 
-			oceanNode.oo = oceanNode.uz * (radius); // origin of ocean frame, in local space
-			
+			oceanNode.oo.Set (oceanNode.uz.x * radius, oceanNode.uz.y * radius, oceanNode.uz.z * radius); // origin of ocean frame, in local space
+
 			//local to ocean transform
 			//computed from oo and ux, uy, uz should be correct
-			Matrix4x4d localToOcean = new Matrix4x4d (
+			Matrix4x4d localToOcean = localToOceanD;
+			localToOcean.Set (
 				oceanNode.ux.x, oceanNode.ux.y, oceanNode.ux.z, -oceanNode.ux.Dot (oceanNode.oo),
 				oceanNode.uy.x, oceanNode.uy.y, oceanNode.uy.z, -oceanNode.uy.Dot (oceanNode.oo),
 				oceanNode.uz.x, oceanNode.uz.y, oceanNode.uz.z, -oceanNode.uz.Dot (oceanNode.oo),
 				0.0, 0.0, 0.0, 1.0);
-			
-			Matrix4x4d cameraToOcean = localToOcean * camToLocal;
-			Matrix4x4d worldToOcean = localToOcean * worldToLocal;
-			
-			Vector3d2 delta = new Vector3d2 (0, 0, 0);
-			
-			if (m_oldlocalToOcean != Matrix4x4d.Identity ())
+
+			Matrix4x4d cameraToOcean = cameraToOceanD;
+			Matrix4x4d.Multiply (localToOcean, camToLocal, cameraToOcean);
+			Matrix4x4d worldToOcean = worldToOceanD;
+			Matrix4x4d.Multiply (localToOcean, worldToLocal, worldToOcean);
+
+			if (m_oldlocalToOceanValid)
 			{
-				delta = localToOcean * (m_oldlocalToOcean.Inverse () * Vector3d2.Zero ());
-				oceanNode.m_Offset += delta;
+				m_oldlocalToOcean.InverseInto (inverseScratchD);
+				inverseScratchD.MultiplyPoint (zeroD, scratchA);
+				localToOcean.MultiplyPoint (scratchA, deltaD);
+				oceanNode.m_Offset.x += deltaD.x;
+				oceanNode.m_Offset.y += deltaD.y;
+				oceanNode.m_Offset.z += deltaD.z;
 			}
 			
 			//reset offset when bigger than 20000 to  avoid floating point issues when later casting the offset to float
@@ -132,15 +169,16 @@ namespace Scatterer
 				oceanNode.m_Offset.y=0.0;
 			}
 			
-			m_oldlocalToOcean = localToOcean;
-			
+			m_oldlocalToOcean.CopyFrom (localToOcean); // copy, not reference-assign: localToOceanD is reused next frame
+			m_oldlocalToOceanValid = true;
+
 			//			Matrix4x4d ctos = ModifiedProjectionMatrix (inCamera); //moved to command buffer
 			//			Matrix4x4d stoc = ctos.Inverse ();
-			
-			Vector3d2 oc = cameraToOcean * Vector3d2.Zero ();
-			oceanNode.height = oc.z;					
-			
-			oceanNode.offset = new Vector3d2 (-oceanNode.m_Offset.x, -oceanNode.m_Offset.y, oceanNode.height);
+
+			cameraToOcean.MultiplyPoint (zeroD, scratchA); // oc
+			oceanNode.height = scratchA.z;
+
+			oceanNode.offset.Set (-oceanNode.m_Offset.x, -oceanNode.m_Offset.y, oceanNode.height);
 			
 			//old horizon code
 			//This breaks down when you tilt the camera by 90 degrees in any direction
@@ -170,21 +208,26 @@ namespace Scatterer
 			//			horizon1 = new Vector3d2 (-beta0, -beta1, 0.0);
 			//			horizon2 = new Vector3d2 (beta0 * beta0 - gamma0, 2.0 * (beta0 * beta1 - gamma1), beta1 * beta1 - gamma2);
 			
-			Vector3d2 sunDir = new Vector3d2 (oceanNode.prolandManager.getDirectionToMainSun ());
-			Vector3d2 oceanSunDir = localToOcean.ToMatrix3x3d () * sunDir;
-			
+			Vector3d sunDirRaw = oceanNode.prolandManager.getDirectionToMainSun ();
+			Vector3d2 sunDir = sunDirD;
+			sunDir.Set (sunDirRaw.x, sunDirRaw.y, sunDirRaw.z);
+			Vector3d2 oceanSunDir = oceanSunDirD;
+			localToOcean.MultiplyVector3x3 (sunDir, oceanSunDir);
+
 			oceanMaterial.SetMatrix (ShaderProperties._Globals_CameraToWorld_PROPERTY, cameraToWorld .ToMatrix4x4());
-			
+
 			oceanMaterial.SetVector (ShaderProperties._Ocean_SunDir_PROPERTY, oceanSunDir.ToVector3 ());
-			
+
 			oceanMaterial.SetMatrix (ShaderProperties._Ocean_CameraToOcean_PROPERTY, cameraToOcean.ToMatrix4x4 ());
-			oceanMaterial.SetMatrix (ShaderProperties._Ocean_OceanToCamera_PROPERTY, cameraToOcean.Inverse ().ToMatrix4x4 ());
-			
+			cameraToOcean.InverseInto (inverseScratchD);
+			oceanMaterial.SetMatrix (ShaderProperties._Ocean_OceanToCamera_PROPERTY, inverseScratchD.ToMatrix4x4 ());
+
 			//			oceanMaterial.SetMatrix (ShaderProperties._Globals_CameraToScreen_PROPERTY, ctos.ToMatrix4x4 ());
 			//			oceanMaterial.SetMatrix (ShaderProperties._Globals_ScreenToCamera_PROPERTY, stoc.ToMatrix4x4 ());
-			
+
 			oceanMaterial.SetMatrix (ShaderProperties._Globals_WorldToOcean_PROPERTY, worldToOcean.ToMatrix4x4 ());
-			oceanMaterial.SetMatrix (ShaderProperties._Globals_OceanToWorld_PROPERTY, worldToOcean.Inverse ().ToMatrix4x4 ());
+			worldToOcean.InverseInto (inverseScratchD);
+			oceanMaterial.SetMatrix (ShaderProperties._Globals_OceanToWorld_PROPERTY, inverseScratchD.ToMatrix4x4 ());
 			
 			oceanMaterial.SetVector (ShaderProperties._Ocean_CameraPos_PROPERTY, oceanNode.offset.ToVector3 ());
 			
@@ -200,9 +243,10 @@ namespace Scatterer
 			//1)for double precision
 			//2)for speed
 			
-			Vector3d2 sphereDir=localToCam * Vector3d2.Zero ();  //vector to center of planet			
+			Vector3d2 sphereDir = sphereDirD;
+			localToCam.MultiplyPoint (zeroD, sphereDir);         //vector to center of planet
 			double OHL = sphereDir.Magnitude ();         		 //distance to center of planet
-			sphereDir = sphereDir.Normalized ();		 		 //direction to center of planet
+			sphereDir.Normalize ();						 		 //direction to center of planet
 			
 			double rHorizon = Math.Sqrt(OHL * OHL - radius * radius);  //distance to the horizon, i.e distance to ocean sphere tangent
 			
@@ -219,13 +263,14 @@ namespace Scatterer
 			{
 				Matrix4x4 planetShineSourcesMatrix=oceanNode.prolandManager.planetShineSourcesMatrix;
 				
-				Vector3d2 oceanSunDir2;
+				Vector3d2 oceanSunDir2 = scratchB;
 				for (int i=0;i<4;i++)
 				{
 					Vector4 row = planetShineSourcesMatrix.GetRow(i);
 					if (row.w != 0f)
 					{
-						oceanSunDir2=localToOcean.ToMatrix3x3d () * new Vector3d2(row.x,row.y,row.z);
+						scratchA.Set (row.x, row.y, row.z);
+						localToOcean.MultiplyVector3x3 (scratchA, oceanSunDir2);
 						planetShineSourcesMatrix.SetRow(i,new Vector4((float)oceanSunDir2.x,(float)oceanSunDir2.y,(float)oceanSunDir2.z,row.w));
 					}
 				}

--- a/scatterer/Utilities/Math/Matrix4x4d.cs
+++ b/scatterer/Utilities/Math/Matrix4x4d.cs
@@ -205,6 +205,86 @@ public class Matrix4x4d
 	{
 	    return Adjoint() * (1.0f / Determinant());
 	}
+
+	// ===== Non-allocating variants (Matrix4x4d is a class, so every operator/Inverse call above
+	// allocates a new matrix + its backing array; these write into caller-provided instances for
+	// per-frame hot paths such as the ocean camera hook). Math is identical to the allocating
+	// versions. =====
+
+	public void Set(double m00, double m01, double m02, double m03,
+					double m10, double m11, double m12, double m13,
+					double m20, double m21, double m22, double m23,
+					double m30, double m31, double m32, double m33)
+	{
+		m[0,0] = m00; m[0,1] = m01; m[0,2] = m02; m[0,3] = m03;
+		m[1,0] = m10; m[1,1] = m11; m[1,2] = m12; m[1,3] = m13;
+		m[2,0] = m20; m[2,1] = m21; m[2,2] = m22; m[2,3] = m23;
+		m[3,0] = m30; m[3,1] = m31; m[3,2] = m32; m[3,3] = m33;
+	}
+
+	public void CopyFrom(Matrix4x4d other)
+	{
+		for (int iRow = 0; iRow < 4; iRow++) {
+			for (int iCol = 0; iCol < 4; iCol++) {
+				m[iRow,iCol] = other.m[iRow,iCol];
+			}
+		}
+	}
+
+	// dest = m1 * m2 (same math as operator*). dest must not alias m1 or m2.
+	public static void Multiply(Matrix4x4d m1, Matrix4x4d m2, Matrix4x4d dest)
+	{
+		for (int iRow = 0; iRow < 4; iRow++) {
+			for (int iCol = 0; iCol < 4; iCol++) {
+				dest.m[iRow,iCol] = m1.m[iRow,0] * m2.m[0,iCol] +
+									m1.m[iRow,1] * m2.m[1,iCol] +
+									m1.m[iRow,2] * m2.m[2,iCol] +
+									m1.m[iRow,3] * m2.m[3,iCol];
+			}
+		}
+	}
+
+	// dest = this * v (same math as operator*(Matrix4x4d, Vector3d2)). Alias-safe (v may be dest).
+	public void MultiplyPoint(Vector3d2 v, Vector3d2 dest)
+	{
+		double vx = v.x, vy = v.y, vz = v.z;
+		double fInvW = 1.0 / (m[3,0] * vx + m[3,1] * vy + m[3,2] * vz + m[3,3]);
+		dest.x = (m[0,0] * vx + m[0,1] * vy + m[0,2] * vz + m[0,3]) * fInvW;
+		dest.y = (m[1,0] * vx + m[1,1] * vy + m[1,2] * vz + m[1,3]) * fInvW;
+		dest.z = (m[2,0] * vx + m[2,1] * vy + m[2,2] * vz + m[2,3]) * fInvW;
+	}
+
+	// dest = upper-left 3x3 of this * v (same math as ToMatrix3x3d() followed by the Matrix3x3d
+	// operator*, without allocating the intermediate Matrix3x3d). Alias-safe (v may be dest).
+	public void MultiplyVector3x3(Vector3d2 v, Vector3d2 dest)
+	{
+		double vx = v.x, vy = v.y, vz = v.z;
+		dest.x = m[0,0] * vx + m[0,1] * vy + m[0,2] * vz;
+		dest.y = m[1,0] * vx + m[1,1] * vy + m[1,2] * vz;
+		dest.z = m[2,0] * vx + m[2,1] * vy + m[2,2] * vz;
+	}
+
+	// dest = this.Inverse() (same math as Adjoint() * (1.0f / Determinant())). dest must not alias this.
+	public void InverseInto(Matrix4x4d dest)
+	{
+		double s = 1.0f / Determinant();
+		dest.m[0,0] =  MINOR(1, 2, 3, 1, 2, 3) * s;
+		dest.m[0,1] = -MINOR(0, 2, 3, 1, 2, 3) * s;
+		dest.m[0,2] =  MINOR(0, 1, 3, 1, 2, 3) * s;
+		dest.m[0,3] = -MINOR(0, 1, 2, 1, 2, 3) * s;
+		dest.m[1,0] = -MINOR(1, 2, 3, 0, 2, 3) * s;
+		dest.m[1,1] =  MINOR(0, 2, 3, 0, 2, 3) * s;
+		dest.m[1,2] = -MINOR(0, 1, 3, 0, 2, 3) * s;
+		dest.m[1,3] =  MINOR(0, 1, 2, 0, 2, 3) * s;
+		dest.m[2,0] =  MINOR(1, 2, 3, 0, 1, 3) * s;
+		dest.m[2,1] = -MINOR(0, 2, 3, 0, 1, 3) * s;
+		dest.m[2,2] =  MINOR(0, 1, 3, 0, 1, 3) * s;
+		dest.m[2,3] = -MINOR(0, 1, 2, 0, 1, 3) * s;
+		dest.m[3,0] = -MINOR(1, 2, 3, 0, 1, 2) * s;
+		dest.m[3,1] =  MINOR(0, 2, 3, 0, 1, 2) * s;
+		dest.m[3,2] = -MINOR(0, 1, 3, 0, 1, 2) * s;
+		dest.m[3,3] =  MINOR(0, 1, 2, 0, 1, 2) * s;
+	}
 	
 	public Vector4d GetColumn(int iCol)
 	{

--- a/scatterer/Utilities/Math/Vector3d2.cs
+++ b/scatterer/Utilities/Math/Vector3d2.cs
@@ -156,6 +156,34 @@ public class Vector3d2
 	{
 		return new Vector3d2(y*v.z - z*v.y, z*v.x - x*v.z, x*v.y - y*v.x);
 	}
+
+	// ===== Non-allocating variants (Vector3d2 is a class, so the methods above allocate on every
+	// call; these write into caller-provided instances for per-frame hot paths). Math is identical. =====
+
+	public void Set(double x, double y, double z)
+	{
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public void CopyFrom(Vector3d2 v)
+	{
+		x = v.x;
+		y = v.y;
+		z = v.z;
+	}
+
+	// dest = this x v (same math as Cross). Alias-safe (dest may be this or v).
+	public void CrossInto(Vector3d2 v, Vector3d2 dest)
+	{
+		double rx = y*v.z - z*v.y;
+		double ry = z*v.x - x*v.z;
+		double rz = x*v.y - y*v.x;
+		dest.x = rx;
+		dest.y = ry;
+		dest.z = rz;
+	}
 	
 	public Vector2d XY()
 	{


### PR DESCRIPTION
The ocean camera-uniform update ran ~4.2 KB/frame of GC (profiler-attributed) because
Matrix4x4d and Vector3d2 are classes: every operator*, Inverse(), Cross(), Normalized(),
Identity() and the "!= Identity()" comparison allocated a fresh instance, several per frame
per active camera.

This adds allocation-free in-place variants (Set/CopyFrom/MultiplyInto/InverseInto/CrossInto
on Matrix4x4d and Vector3d2) and rewrites updateCameraSpecificUniforms to reuse cached
scratch instances, with the math transcribed verbatim (MINOR/Determinant/Adjoint in the
original operation order) so results are bit-identical. m_oldlocalToOcean is copied by value
rather than reference-aliased. Ocean rendering (transparency, reflections, sun glint, shore
interaction) is visually unchanged.

Found with the Unity profiler while hunting per-frame GC in a heavily-modded install.
